### PR TITLE
Modified Gitrob to also scan GitHub organization private repositories. 

### DIFF
--- a/common/interfaces.go
+++ b/common/interfaces.go
@@ -3,5 +3,6 @@ package common
 type IClient interface {
 	GetUserOrOrganization(login string) (*Owner, error)
 	GetRepositoriesFromOwner(target Owner) ([]*Repository, error)
+	GetRepositoriesFromOrganization(target Owner) ([]*Repository, error)
 	GetOrganizationMembers(target Owner) ([]*Owner, error)
 }

--- a/core/analysis.go
+++ b/core/analysis.go
@@ -71,7 +71,6 @@ func GatherRepositories(sess *Session) {
 					wg.Done()
 					return
 				}
-				//repos, err := sess.Client.GetRepositoriesFromOwner(*target)
 				if *target.Type == "Organization" {
 					repos, err = sess.Client.GetRepositoriesFromOrganization(*target)
 				} else {

--- a/github/git.go
+++ b/github/git.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"strings"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 	"io/ioutil"
 
@@ -9,6 +10,7 @@ import (
 
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport/http"
 )
 
 func CloneRepository(cloneConfig *common.CloneConfiguration) (*git.Repository, string, error) {
@@ -19,7 +21,14 @@ func CloneRepository(cloneConfig *common.CloneConfiguration) (*git.Repository, s
 		ReferenceName: plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", *cloneConfig.Branch)),
 		SingleBranch:  true,
 		Tags:          git.NoTags,
+		Auth: &http.BasicAuth{
+			Username: *cloneConfig.Username,
+			Password: *cloneConfig.Token,
+		},
 	}
+
+	cloneOptions.URL = strings.Replace(cloneOptions.URL, "git@github.com:", "https://github.com/", -1)
+
 
 	var repository *git.Repository
 	var err error

--- a/gitlab/apiClient.go
+++ b/gitlab/apiClient.go
@@ -112,6 +112,29 @@ func (c Client) GetRepositoriesFromOwner(target common.Owner) ([]*common.Reposit
 	return allProjects, nil
 }
 
+func (c Client) GetRepositoriesFromOrganization(target common.Owner) ([]*common.Repository, error) {
+        var allProjects []*common.Repository
+        id := int(*target.ID)
+        if *target.Type == common.TargetTypeUser {
+                userProjects, err := c.getUserProjects(id)
+                if err != nil {
+                        return nil, err
+                }
+                for _, project := range userProjects {
+                        allProjects = append(allProjects, project)
+                }
+        } else {
+                groupProjects, err := c.getGroupProjects(target)
+                if err != nil {
+                        return nil, err
+                }
+                for _, project := range groupProjects {
+                        allProjects = append(allProjects, project)
+                }
+        }
+        return allProjects, nil
+}
+
 func (c Client) getUser(login string) (*gitlab.User, error) {
 	users, _, err := c.apiClient.Users.ListUsers(&gitlab.ListUsersOptions{Username: gitlab.String(login)})
 	if err != nil {


### PR DESCRIPTION
I'm hoping this change may be useful for someone else.

These changes modify Gitrob to also scan your GitHub organization private repositories that the access key you use has access to.  This was done as part of evaluating Gitrob for internal company use.

Important: The interface changes are replicated in the GitLab implementation, but are not fully implemented.  I don't currently have a GitLab account to proceed with this.

I'm happy to discuss any of this further.