### PR TITLE
fix(github): cloned repositories were not deleted afterwards

### DIFF
--- a/github/git.go
+++ b/github/git.go
@@ -34,7 +34,7 @@ func CloneRepository(cloneConfig *common.CloneConfiguration) (*git.Repository, s
 	var err error
 	var dir string
 	if !*cloneConfig.InMemClone {
-		dir, err := ioutil.TempDir("", "gitrob")
+		dir, err = ioutil.TempDir("", "gitrob")
 		if err != nil {
 			return nil, "", err
 		}


### PR DESCRIPTION
GitHub repositories were not deleted after analysis, this is because the **path** variable in the `AnalyzeRepositories()` function (`core/analysis.go`) was an empty string.

After some analysis I figured out that the temporary directory `dir` created in `github/git.go` was declared and assigned instead of just assigned, thus shadowing the `dir` declaration on line 35, resulting in the returned variable being empty.